### PR TITLE
feat: add table column generation functionality

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -33,3 +33,4 @@
 /bin                     export-ignore
 /postcss.config.js       export-ignore
 /commitlint.config.cjs    export-ignore
+/.phpunit.cache           export-ignore

--- a/src/Support/Commands/Concerns/CanBeGenerated.php
+++ b/src/Support/Commands/Concerns/CanBeGenerated.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\FilamentToolKit\Support\Commands\Concerns;
+
+use Illuminate\Support\Facades\Schema;
+
+trait CanBeGenerated
+{
+    private function getTableFromModel(string $modelClass): string
+    {
+
+        return (new $modelClass())->getTable();
+    }
+
+    private function getColumnListing(string $modelClass): array
+    {
+
+        $tableName = $this->getTableFromModel($modelClass);
+
+        return Schema::getColumnListing($tableName);
+    }
+
+    private function getColumnType(string $tableName, string $columnName): string
+    {
+
+        return Schema::getColumnType($tableName, $columnName);
+    }
+
+    private function getClassName(string $columnName): string|array
+    {
+
+        return str_replace('_', '', ucwords($columnName, '_'));
+    }
+
+    private function makeColumns(string $tableFqn, array $tableColumns): array
+    {
+
+        $className = class_basename($tableFqn);
+
+        $tableColumns[] = "{$className}::make(),";
+
+        return $tableColumns;
+    }
+
+    private function generateUseStatement(string $tableFqn): string
+    {
+
+        return 'use '.ltrim($tableFqn, '\\').';';
+    }
+
+    private function formatColumns(array $tableColumns): string
+    {
+
+        $formattedColumns = array_map(function ($column) {
+
+            return mb_str_pad($column, 30);
+        }, $tableColumns);
+
+        return implode(PHP_EOL, $formattedColumns);
+    }
+}

--- a/src/Support/Commands/Concerns/CanGenerateTableColumns.php
+++ b/src/Support/Commands/Concerns/CanGenerateTableColumns.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\FilamentToolKit\Support\Commands\Concerns;
+
+trait CanGenerateTableColumns
+{
+    use CanBeGenerated;
+    use InteractsWithGithub;
+
+    private array $tableImportStatements = [];
+
+    public function getTableImportStatements(): array
+    {
+
+        return $this->tableImportStatements;
+    }
+
+    protected function generateTableColumns(string $modelClass): string
+    {
+        $columns = $this->getColumnListing($modelClass);
+
+        $tableColumns = [];
+
+        foreach ($columns as $column) {
+
+            $tableFqn = $this->findMatchingColumnClass($column, $modelClass);
+
+            if (! $tableFqn) {
+                \Laravel\Prompts\info("No matching column class found for column: {$column}");
+
+                $this->createGitHubIssue($column, 'Table');
+
+                continue;
+            }
+
+            $this->tableImportStatements[] = $this->generateUseStatement($tableFqn);
+
+            $tableColumns = $this->makeColumns($tableFqn, $tableColumns);
+        }
+
+        return $this->formatColumns($tableColumns);
+    }
+
+    private function findMatchingColumnClass(string $columnName, string $modelClass): ?string
+    {
+
+        $tableName = $this->getTableFromModel($modelClass);
+
+        $columnType = $this->getColumnType($tableName, $columnName);
+
+        $className = $this->getClassName($columnName);
+
+        if ($columnType === 'boolean') {
+            $className .= 'ToggleColumn';
+            $namespace = 'Akira\\FilamentToolKit\\Table\\Columns\\Toggles\\';
+        } else {
+            $className .= 'TextColumn';
+            $namespace = 'Akira\\FilamentToolKit\\Table\\Columns\\Text\\';
+        }
+
+        $tableFqn = $namespace.$className;
+
+        if (class_exists($tableFqn)) {
+            return '\\'.$tableFqn;
+        }
+
+        return null;
+    }
+}

--- a/src/Support/Commands/Concerns/InteractsWithGithub.php
+++ b/src/Support/Commands/Concerns/InteractsWithGithub.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\FilamentToolKit\Support\Commands\Concerns;
+
+trait InteractsWithGithub
+{
+    protected function createGitHubIssue(
+        string $columnName,
+        string $prefix = ''
+    ): void {
+
+        // Add the prefix to the title if provided
+        $title = "{$prefix} Missing Column Class: {$columnName}";
+        $body = "No matching column class found for column: {$columnName}";
+
+        // Generate the issue URL
+        $url = 'https://github.com/akira-io/filament-tool-kit/issues/new?title='
+            .urlencode($title).'&body='.urlencode($body);
+
+        // Inform the user to create the issue
+        \Laravel\Prompts\info("Please create an issue on GitHub for the missing column: {$columnName}");
+        \Laravel\Prompts\info("You can do so by visiting this URL: {$url}");
+    }
+}

--- a/stubs/TableColumns.stub
+++ b/stubs/TableColumns.stub
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace {{ namespace }};
 
-use Akira\FilamentToolKit\Table\Columns\Text\IdTextColumn;
+{{ fqn }}
 
 class {{ modelClass }}TableColumns
 {
     public static function make(): array
     {
         return [
-            IdTextColumn::make(),
+{{ columns }}
         ];
     }
 }


### PR DESCRIPTION
Introduce `CanGenerateTableColumns` trait to handle table column generation in `MakeResourceCommand`. This includes creating GitHub issues for missing column classes and updating the table columns stub to dynamically generate column definitions.

