### PR TITLE
feat: implement form field generation

### DIFF
--- a/src/Commands/MakeResourceCommand.php
+++ b/src/Commands/MakeResourceCommand.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Akira\FilamentToolKit\Commands;
 
+use Akira\FilamentToolKit\Support\Commands\Concerns\CanBeGenerated;
+use Akira\FilamentToolKit\Support\Commands\Concerns\CanGenerateFormFields;
 use Akira\FilamentToolKit\Support\Commands\Concerns\CanGenerateTableColumns;
 use Akira\FilamentToolKit\Support\Commands\Concerns\CanManipulateFiles;
+use Akira\FilamentToolKit\Support\Commands\Concerns\InteractsWithGithub;
 use Filament\Facades\Filament;
 use Filament\Panel;
 use Filament\Support\Commands\Concerns\CanIndentStrings;
@@ -17,9 +20,12 @@ use function Laravel\Prompts\text;
 
 final class MakeResourceCommand extends Command
 {
+    use CanBeGenerated;
+    use CanGenerateFormFields;
     use CanGenerateTableColumns;
     use CanIndentStrings;
     use CanManipulateFiles;
+    use InteractsWithGithub;
 
     public $signature = 'tool-kit:resource{model? : The model name} {--F|force} {--model-namespace=} {--panel=} {--simple} {--multiple } {--generate}}';
 
@@ -331,6 +337,15 @@ final class MakeResourceCommand extends Command
                 'fqn' => $this->indentString(implode(PHP_EOL, $this->getTableImportStatements()), 0),
                 'modelClass' => $modelClass,
                 'columns' => $this->indentString($tableColumns, 3),
+            ]);
+
+            $formFields = $this->generateFormFields("{$modelNamespace}\\{$modelClass}");
+
+            $this->copyStubToApp('FormSchema', $formSchemaPath, [
+                'namespace' => "{$namespace}\\{$resourceClass}\\Forms",
+                'fqn' => $this->indentString(implode(PHP_EOL, $this->getFormImportStatements()), 0),
+                'modelClass' => $modelClass,
+                'fields' => $this->indentString($formFields, 3),
             ]);
         }
     }

--- a/src/Support/Commands/Concerns/CanGenerateFormFields.php
+++ b/src/Support/Commands/Concerns/CanGenerateFormFields.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\FilamentToolKit\Support\Commands\Concerns;
+
+trait CanGenerateFormFields
+{
+    use CanBeGenerated;
+    use InteractsWithGithub;
+
+    private array $formImportStatements = [];
+
+    public function getFormImportStatements(): array
+    {
+
+        return $this->formImportStatements;
+    }
+
+    protected function generateFormFields(string $modelClass): string
+    {
+        $columns = $this->getColumnListing($modelClass);
+
+        $tableColumns = [];
+
+        foreach ($columns as $column) {
+
+            $tableFqn = $this->findFormMatchingColumnClass($column, $modelClass);
+
+            if (in_array($column, ['id', 'created_at', 'updated_at', 'remember_token', 'email_verified_at'])) {
+                continue;
+            }
+
+            if (! $tableFqn) {
+
+                $this->createGitHubIssue($column, 'Form');
+
+                continue;
+            }
+
+            $this->formImportStatements[] = $this->generateUseStatement($tableFqn);
+
+            $tableColumns = $this->makeColumns($tableFqn, $tableColumns);
+        }
+
+        return $this->formatColumns($tableColumns);
+    }
+
+    private function findFormMatchingColumnClass(string $columnName, string $modelClass): ?string
+    {
+
+        $tableName = $this->getTableFromModel($modelClass);
+
+        $columnType = $this->getColumnType($tableName, $columnName);
+
+        $className = $this->getClassName($columnName);
+
+        if ($columnType === 'boolean') {
+            $className .= 'Toggle';
+            $namespace = 'Akira\\FilamentToolKit\\Form\\Toggles\\';
+        } elseif ($columnType === 'date') {
+            $className .= 'DatePicker';
+            $namespace = 'Akira\\FilamentToolKit\\Form\\DatePickers\\';
+        } else {
+            $className .= 'TextInput';
+            $namespace = 'Akira\\FilamentToolKit\\Form\\Inputs\\';
+        }
+
+        $tableFqn = $namespace.$className;
+
+        if (class_exists($tableFqn)) {
+            return '\\'.$tableFqn;
+        }
+
+        return null;
+    }
+}

--- a/src/Support/Commands/Concerns/CanGenerateTableColumns.php
+++ b/src/Support/Commands/Concerns/CanGenerateTableColumns.php
@@ -25,10 +25,13 @@ trait CanGenerateTableColumns
 
         foreach ($columns as $column) {
 
-            $tableFqn = $this->findMatchingColumnClass($column, $modelClass);
+            $tableFqn = $this->findTableMatchingColumnClass($column, $modelClass);
+
+            if (in_array($column, ['password'])) {
+                continue;
+            }
 
             if (! $tableFqn) {
-                \Laravel\Prompts\info("No matching column class found for column: {$column}");
 
                 $this->createGitHubIssue($column, 'Table');
 
@@ -43,7 +46,7 @@ trait CanGenerateTableColumns
         return $this->formatColumns($tableColumns);
     }
 
-    private function findMatchingColumnClass(string $columnName, string $modelClass): ?string
+    private function findTableMatchingColumnClass(string $columnName, string $modelClass): ?string
     {
 
         $tableName = $this->getTableFromModel($modelClass);

--- a/src/Support/Commands/Concerns/InteractsWithGithub.php
+++ b/src/Support/Commands/Concerns/InteractsWithGithub.php
@@ -13,14 +13,14 @@ trait InteractsWithGithub
 
         // Add the prefix to the title if provided
         $title = "{$prefix} Missing Column Class: {$columnName}";
-        $body = "No matching column class found for column: {$columnName}";
+        $body = "No matching  class found for  {$prefix} column: {$columnName}";
 
         // Generate the issue URL
         $url = 'https://github.com/akira-io/filament-tool-kit/issues/new?title='
             .urlencode($title).'&body='.urlencode($body);
 
         // Inform the user to create the issue
-        \Laravel\Prompts\info("Please create an issue on GitHub for the missing column: {$columnName}");
+        \Laravel\Prompts\info("Please create an issue on GitHub for the missing {$prefix} : {$columnName}");
         \Laravel\Prompts\info("You can do so by visiting this URL: {$url}");
     }
 }

--- a/stubs/FormSchema.stub
+++ b/stubs/FormSchema.stub
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace {{ namespace }};
 
 use Filament\Forms\Components\Section;
+{{ fqn }}
 
 class {{ modelClass }}FormSchema
 {
@@ -20,7 +21,7 @@ class {{ modelClass }}FormSchema
     private static function getFormSchema(): array
     {
         return [
-            //
+{{ fields }}
         ];
     }
 }


### PR DESCRIPTION
Introduce `CanGenerateFormFields` trait to dynamically generate form fields in `MakeResourceCommand`. This includes creating GitHub issues for missing form field classes and updating the form schema stub to include generated fields. Additionally, ensure table column generation skips password fields.
