### PR TITLE
feat: add info list entries generation

### DIFF
--- a/src/Commands/MakeResourceCommand.php
+++ b/src/Commands/MakeResourceCommand.php
@@ -6,6 +6,7 @@ namespace Akira\FilamentToolKit\Commands;
 
 use Akira\FilamentToolKit\Support\Commands\Concerns\CanBeGenerated;
 use Akira\FilamentToolKit\Support\Commands\Concerns\CanGenerateFormFields;
+use Akira\FilamentToolKit\Support\Commands\Concerns\CanGenerateInfoListEntries;
 use Akira\FilamentToolKit\Support\Commands\Concerns\CanGenerateTableColumns;
 use Akira\FilamentToolKit\Support\Commands\Concerns\CanManipulateFiles;
 use Akira\FilamentToolKit\Support\Commands\Concerns\InteractsWithGithub;
@@ -22,6 +23,7 @@ final class MakeResourceCommand extends Command
 {
     use CanBeGenerated;
     use CanGenerateFormFields;
+    use CanGenerateInfoListEntries;
     use CanGenerateTableColumns;
     use CanIndentStrings;
     use CanManipulateFiles;
@@ -346,6 +348,15 @@ final class MakeResourceCommand extends Command
                 'fqn' => $this->indentString(implode(PHP_EOL, $this->getFormImportStatements()), 0),
                 'modelClass' => $modelClass,
                 'fields' => $this->indentString($formFields, 3),
+            ]);
+
+            $infoListEntries = $this->generateInfoListEntries("{$modelNamespace}\\{$modelClass}");
+
+            $this->copyStubToApp('InfoListSchema', $infolistSchemaPath, [
+                'namespace' => "{$namespace}\\{$resourceClass}\\InfoLists",
+                'fqn' => $this->indentString(implode(PHP_EOL, $this->getInfoListImportStatements()), 0),
+                'modelClass' => $modelClass,
+                'entries' => $this->indentString($infoListEntries, 3),
             ]);
         }
     }

--- a/src/Support/Commands/Concerns/CanGenerateInfoListEntries.php
+++ b/src/Support/Commands/Concerns/CanGenerateInfoListEntries.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\FilamentToolKit\Support\Commands\Concerns;
+
+trait CanGenerateInfoListEntries
+{
+    use CanBeGenerated;
+    use InteractsWithGithub;
+
+    private array $infoListImportStatements = [];
+
+    public function getInfoListImportStatements(): array
+    {
+
+        return $this->infoListImportStatements;
+    }
+
+    protected function generateInfoListEntries(string $modelClass): string
+    {
+        $columns = $this->getColumnListing($modelClass);
+
+        $tableColumns = [];
+
+        foreach ($columns as $column) {
+
+            $tableFqn = $this->findInfoListEntriesMatchingColumnClass($column, $modelClass);
+
+            if (in_array($column, ['created_at', 'updated_at', 'remember_token', 'password'])) {
+                continue;
+            }
+
+            if (! $tableFqn) {
+
+                $this->createGitHubIssue($column, 'InfoList');
+
+                continue;
+            }
+
+            $this->infoListImportStatements[] = $this->generateUseStatement($tableFqn);
+
+            $tableColumns = $this->makeColumns($tableFqn, $tableColumns);
+        }
+
+        return $this->formatColumns($tableColumns);
+    }
+
+    private function findInfoListEntriesMatchingColumnClass(string $columnName, string $modelClass): ?string
+    {
+
+        $tableName = $this->getTableFromModel($modelClass);
+
+        $columnType = $this->getColumnType($tableName, $columnName);
+
+        $className = $this->getClassName($columnName);
+
+        if ($columnType === 'boolean') {
+            $className .= 'IconEntry';
+            $namespace = 'Akira\\FilamentToolKit\\InfoList\\Entries\\';
+        } else {
+            $className .= 'TextEntry';
+            $namespace = 'Akira\\FilamentToolKit\\InfoList\\Entries\\';
+        }
+
+        $tableFqn = $namespace.$className;
+
+        if (class_exists($tableFqn)) {
+            return '\\'.$tableFqn;
+        }
+
+        return null;
+    }
+}

--- a/src/Support/Commands/Concerns/InteractsWithGithub.php
+++ b/src/Support/Commands/Concerns/InteractsWithGithub.php
@@ -12,7 +12,7 @@ trait InteractsWithGithub
     ): void {
 
         // Add the prefix to the title if provided
-        $title = "{$prefix} Missing Column Class: {$columnName}";
+        $title = "{$prefix} Missing Class: {$columnName}";
         $body = "No matching  class found for  {$prefix} column: {$columnName}";
 
         // Generate the issue URL

--- a/stubs/InfolistSchema.stub
+++ b/stubs/InfolistSchema.stub
@@ -6,6 +6,7 @@ namespace {{ namespace }};
 
 use Akira\FilamentToolKit\InfoList\Entries\CreatedAtTextEntry;
 use Akira\FilamentToolKit\InfoList\Entries\UpdatedAtTextEntry;
+{{ fqn }}
 
 use Filament\Infolists\Components\Section;
 
@@ -48,7 +49,7 @@ class {{ modelClass }}InfoListSchema
     private static function getInformationSectionSchema(): array
     {
         return [
-            //
+{{ entries }}
         ];
     }
 }


### PR DESCRIPTION
Add `CanGenerateInfoListEntries` trait to `MakeResourceCommand` for dynamic creation of info list entries. This includes generating and formatting entries, updating the schema stub with new entries, and creating GitHub issues for missing entry classes. Minor adjustment made to issue title prefix in `InteractsWithGithub` trait.