### PR TITLE
feat: add RememberTokenTextColumn

### DIFF
--- a/resources/lang/pt_PT.json
+++ b/resources/lang/pt_PT.json
@@ -85,5 +85,6 @@
     "Emergency Phone": "Telefone de Emergência",
     "Address": "Morada",
     "Updated At": "Atualizado em",
-    "Deleted At": "Apagado em"
+    "Deleted At": "Apagado em",
+    "Remember Token": "Token de recordação"
 }

--- a/scripts/table/text.json
+++ b/scripts/table/text.json
@@ -11,5 +11,6 @@
   "emergency_phone": "Telefone de emergência",
   "address": "Morada",
   "document_number": "Nº documento",
-  "discount": "Desconto"
+  "discount": "Desconto",
+  "remember_token": "Token de recordação"
 }

--- a/src/Table/Columns/Text/RememberTokenTextColumn.php
+++ b/src/Table/Columns/Text/RememberTokenTextColumn.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\FilamentToolKit\Table\Columns\Text;
+
+use Filament\Tables\Columns\TextColumn;
+
+final class RememberTokenTextColumn
+{
+    public static function make(): TextColumn
+    {
+        return TextColumn::make('remember_token')
+            ->label(__('Remember Token'));
+    }
+}


### PR DESCRIPTION
Introduce `RememberTokenTextColumn` class for handling 'remember_token' column in table components. Updated Portuguese translations to include 'Remember Token' and corresponding JSON script. This change ensures consistent internationalization and column configurations for remember tokens.
