### PR TITLE
feat: add IdTextEntry class

### DIFF
--- a/resources/lang/pt_PT.json
+++ b/resources/lang/pt_PT.json
@@ -86,5 +86,6 @@
     "Address": "Morada",
     "Updated At": "Atualizado em",
     "Deleted At": "Apagado em",
-    "Remember Token": "Token de recordação"
+    "Remember Token": "Token de recordação",
+    "Id": "Id"
 }

--- a/scripts/infoLists/text.json
+++ b/scripts/infoLists/text.json
@@ -14,5 +14,6 @@
   "successful_rows": "Linhas com sucesso",
   "email": "E-mail",
   "emergency_phone": "Telefone de emergência",
-  "address": "Morada"
+  "address": "Morada",
+  "id": "Id"
 }

--- a/src/InfoList/Entries/IdTextEntry.php
+++ b/src/InfoList/Entries/IdTextEntry.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akira\FilamentToolKit\InfoList\Entries;
+
+use Filament\Infolists\Components\TextEntry;
+
+final class IdTextEntry
+{
+    public static function make(): TextEntry
+    {
+        return TextEntry::make('id')
+            ->label(__('Id'))
+            ->badge();
+    }
+}


### PR DESCRIPTION
Add `IdTextEntry` class for managing 'id' text entries in the InfoList components. Updated Portuguese translations and JSON script to include 'Id'. This ensures proper handling and consistent internationalization of 'id' entries in the application.

